### PR TITLE
Add option to use a regex for matching CMDs and fixing a bug

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 )
 
+// Remote respresents a WinRM server
 type Remote struct {
 	Host    string
 	Port    int
@@ -16,6 +17,7 @@ type Remote struct {
 	service *wsman
 }
 
+// NewRemote returns a new initialized Remote
 func NewRemote() *Remote {
 	mux := http.NewServeMux()
 	srv := httptest.NewServer(mux)
@@ -32,14 +34,17 @@ func NewRemote() *Remote {
 	return &remote
 }
 
+// Close closes the WinRM server
 func (r *Remote) Close() {
 	r.server.Close()
 }
 
+// CommandFunc respresents a function used to mock WinRM commands
 type CommandFunc func(out, err io.Writer) (exitCode int)
 
-func (r *Remote) CommandFunc(cmd string, f CommandFunc) {
-	r.service.HandleCommand(cmd, f)
+// CommandFunc adds a WinRM command mock function to the WinRM server
+func (r *Remote) CommandFunc(cmd string, regex string, f CommandFunc) {
+	r.service.HandleCommand(cmd, regex, f)
 }
 
 func splitAddr(addr string) (host string, port int, err error) {

--- a/remote.go
+++ b/remote.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -39,12 +40,30 @@ func (r *Remote) Close() {
 	r.server.Close()
 }
 
+// MatcherFunc respresents a function used to match WinRM commands
+type MatcherFunc func(candidate string) bool
+
+// MatchText return a new MatcherFunc based on text matching
+func MatchText(text string) MatcherFunc {
+	return func(candidate string) bool {
+		return text == candidate
+	}
+}
+
+// MatchPattern return a new MatcherFunc based on pattern matching
+func MatchPattern(pattern string) MatcherFunc {
+	r := regexp.MustCompile(pattern)
+	return func(candidate string) bool {
+		return r.MatchString(candidate)
+	}
+}
+
 // CommandFunc respresents a function used to mock WinRM commands
 type CommandFunc func(out, err io.Writer) (exitCode int)
 
 // CommandFunc adds a WinRM command mock function to the WinRM server
-func (r *Remote) CommandFunc(cmd string, regex string, f CommandFunc) {
-	r.service.HandleCommand(cmd, regex, f)
+func (r *Remote) CommandFunc(m MatcherFunc, f CommandFunc) {
+	r.service.HandleCommand(m, f)
 }
 
 func splitAddr(addr string) (host string, port int, err error) {

--- a/wsman.go
+++ b/wsman.go
@@ -8,10 +8,10 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/masterzen/winrm/soap"
 	"github.com/masterzen/xmlpath"
+	"github.com/satori/go.uuid"
 )
 
 type wsman struct {
@@ -27,7 +27,7 @@ type command struct {
 }
 
 func (w *wsman) HandleCommand(cmd string, regex string, f CommandFunc) string {
-	id := newID("cmd")
+	id := uuid.NewV4().String()
 	w.commands = append(w.commands, &command{
 		id:      id,
 		text:    cmd,
@@ -111,8 +111,8 @@ func (w *wsman) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		stdout := bytes.NewBuffer(make([]byte, 0))
-		stderr := bytes.NewBuffer(make([]byte, 0))
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
 		result := cmd.handler(stdout, stderr)
 		content := base64.StdEncoding.EncodeToString(stdout.Bytes())
 
@@ -177,8 +177,4 @@ func readCommandIDFromDesiredStream(env *xmlpath.Node) string {
 
 	id, _ := xpath.String(env)
 	return id
-}
-
-func newID(prefix string) string {
-	return fmt.Sprintf("%s-%d", prefix, uint32(time.Now().UTC().Unix()))
 }

--- a/wsman_test.go
+++ b/wsman_test.go
@@ -54,7 +54,7 @@ func Test_creating_a_shell(t *testing.T) {
 
 func Test_executing_a_command(t *testing.T) {
 	w := &wsman{}
-	id := w.HandleCommand("echo tacos", "", func(out, err io.Writer) int {
+	id := w.HandleCommand(MatchText("echo tacos"), func(out, err io.Writer) int {
 		return 0
 	})
 
@@ -90,7 +90,7 @@ func Test_executing_a_command(t *testing.T) {
 
 func Test_executing_a_regex_command(t *testing.T) {
 	w := &wsman{}
-	id := w.HandleCommand("", `echo .* >> C:\file.cmd`, func(out, err io.Writer) int {
+	id := w.HandleCommand(MatchPattern(`echo .* >> C:\file.cmd`), func(out, err io.Writer) int {
 		return 0
 	})
 
@@ -126,7 +126,7 @@ func Test_executing_a_regex_command(t *testing.T) {
 
 func Test_receiving_command_results(t *testing.T) {
 	w := &wsman{}
-	id := w.HandleCommand("echo tacos", "", func(out, err io.Writer) int {
+	id := w.HandleCommand(MatchText("echo tacos"), func(out, err io.Writer) int {
 		out.Write([]byte("tacos"))
 		return 0
 	})

--- a/wsman_test.go
+++ b/wsman_test.go
@@ -26,7 +26,7 @@ func Test_creating_a_shell(t *testing.T) {
 					<rsp:InputStream>stdin</rsp:InputStream>
 					<rsp:OutputStreams>stdout stderr</rsp:OutputStreams>
 				</rsp:Shell>
-			</env:Body>		
+			</env:Body>
 		</env:Envelope>`))
 
 	w.ServeHTTP(res, req)
@@ -83,7 +83,7 @@ func Test_executing_a_command(t *testing.T) {
 
 	result, _ := xpath.String(env)
 	if result != id {
-		t.Error("Expected CommandId=%s but was \"%s\"", id, result)
+		t.Errorf("Expected CommandId=%s but was \"%s\"", id, result)
 	}
 }
 

--- a/wsman_test.go
+++ b/wsman_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/masterzen/winrm/soap"
 	"github.com/masterzen/xmlpath"
+	"github.com/satori/go.uuid"
 )
 
 func Test_creating_a_shell(t *testing.T) {
@@ -102,7 +103,7 @@ func Test_executing_a_regex_command(t *testing.T) {
 			<env:Body>
 				<rsp:CommandLine><rsp:Command>"echo %d >> C:\file.cmd"</rsp:Command></rsp:CommandLine>
 			</env:Body>
-		</env:Envelope>`, newID("something-dynamic"))))
+		</env:Envelope>`, uuid.NewV4().String())))
 
 	w.ServeHTTP(res, req)
 	if res.Code != http.StatusOK {


### PR DESCRIPTION
Without this option it’s impossible to match any commands that have some generated parts in them. Especially any `winrmcp` commands will fail without this option.

Besides adding this option, I also tweaked and commented a few `golint` and `go vet` things and updated and added a test.
